### PR TITLE
Etd 126: open telemetry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,4 +9,7 @@ CONSOLE_LOGGING_ONLY=false
 LOG_LEVEL=DEBUG
 CONSUME_QUEUE_NAME: etd_in_storage_mjv
 PUBLISH_QUEUE_NAME: etd_in_storage_mjv
-BROKER_URL: "ampqs://un:pw@mybroker.com:5671"
+BROKER_URL="ampqs://un:pw@mybroker.com:5671"
+
+JAEGER_NAME="http://localhost:4317"
+JAEGER_SERVICE_NAME=ETD

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: [3.11.4]
+        python-version: [3.11.3]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: [3.11.3]
+        python-version: [3.11.4]
     runs-on: ubuntu-latest
 
     steps:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,11 @@ celery==5.2.7
 certifi==2022.12.7
 coverage==7.2.6
 iniconfig==2.0.0
+opentelemetry-api==1.19.0
+opentelemetry-sdk==1.19.0
+opentelemetry-exporter-jaeger==1.19.0
+opentelemetry-exporter-otlp-proto-grpc==1.19.0
+opentelemetry-semantic-conventions==0.40b0
 packaging==23.1
 pluggy==1.0.0
 project-paths==1.1.1

--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -54,7 +54,8 @@ def send_to_alma(json_message):
             else:
                 logger.debug("dash_feature_flag MUST BE ON FOR THE ALMA \
                     HOLDING TO BE CREATED. dash_feature_flag IS SET TO OFF")
-                current_span.add_event("dash_feature_flag MUST BE ON FOR THE ALMA \
+                current_span.add_event("dash_feature_flag \
+                    MUST BE ON FOR THE ALMA \
                     HOLDING TO BE CREATED. dash_feature_flag IS SET TO OFF")
         else:
             # Feature is off so do hello world

--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -2,6 +2,14 @@ from celery import Celery
 import os
 import logging
 import etd
+import json
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+        OTLPSpanExporter)
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.resources import SERVICE_NAME
 
 app = Celery()
 app.config_from_object('celeryconfig')
@@ -12,11 +20,26 @@ FEATURE_FLAGS = "feature_flags"
 ALMA_FEATURE_FLAG = "alma_feature_flag"
 DASH_FEATURE_FLAG = "dash_feature_flag"
 
+# tracing setup
+JAEGER_NAME = os.getenv('JAEGER_NAME')
+JAEGER_SERVICE_NAME = os.getenv('JAEGER_SERVICE_NAME')
 
+resource = Resource(attributes={SERVICE_NAME: JAEGER_SERVICE_NAME})
+trace.set_tracer_provider(TracerProvider(resource=resource))
+tracer = trace.get_tracer(__name__)
+
+otlp_exporter = OTLPSpanExporter(endpoint=JAEGER_NAME, insecure=True)
+
+span_processor = BatchSpanProcessor(otlp_exporter)
+trace.get_tracer_provider().add_span_processor(span_processor)
+
+
+@tracer.start_as_current_span("send_to_alma")
 @app.task(serializer='json', name='etd-alma-service.tasks.send_to_alma')
 def send_to_alma(json_message):
     logger.debug("message")
     logger.debug(json_message)
+    current_span = trace.get_current_span()
     new_message = {"hello": "from etd-alma-service"}
     if FEATURE_FLAGS in json_message:
         feature_flags = json_message[FEATURE_FLAGS]
@@ -27,13 +50,18 @@ def send_to_alma(json_message):
                     feature_flags[DASH_FEATURE_FLAG] == "on":
                 # Create Alma Record
                 logger.debug("FEATURE IS ON>>>>>CREATE ALMA RECORD")
+                current_span.add_event("FEATURE IS ON>>>>>CREATE ALMA RECORD")
             else:
                 logger.debug("dash_feature_flag MUST BE ON FOR THE ALMA \
+                    HOLDING TO BE CREATED. dash_feature_flag IS SET TO OFF")
+                current_span.add_event("dash_feature_flag MUST BE ON FOR THE ALMA \
                     HOLDING TO BE CREATED. dash_feature_flag IS SET TO OFF")
         else:
             # Feature is off so do hello world
             logger.debug("FEATURE FLAGS FOUND")
             logger.debug(json_message[FEATURE_FLAGS])
+            current_span.add_event("FEATURE FLAGS FOUND")
+            current_span.add_event(json.dumps(json_message[FEATURE_FLAGS]))
 
     # If only unit testing, return the message and
     # do not trigger the next task.
@@ -42,6 +70,7 @@ def send_to_alma(json_message):
 
     # publish to ingested_into_alma for helloworld,
     # eventually webhooks will do that instead
+    current_span.add_event("to next queue")
     app.send_task("etd-alma-monitor-service.tasks.send_to_drs",
                   args=[new_message], kwargs={},
                   queue=os.getenv('PUBLISH_QUEUE_NAME'))


### PR DESCRIPTION
**ETD-126: open telemetry tracing calls*
* * *

**JIRA Ticket**: https://jira.huit.harvard.edu/browse/ETD-126


# What does this Pull Request do?
this adds tracing calls to the dash service

# How should this be tested?

first start a local version of jaeger:

` docker pull jaegertracing/all-in-one:latest`
then
`docker run -d --name jaeger \
  -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 \
  -e COLLECTOR_OTLP_ENABLED=true \
  -p 6831:6831/udp \
  -p 6832:6832/udp \
  -p 5778:5778 \
  -p 16686:16686 \
  -p 4317:4317 \
  -p 4318:4318 \
  -p 14250:14250 \
  -p 14268:14268 \
  -p 14269:14269 \
  -p 9411:9411 \
  jaegertracing/all-in-one:latest`

then set the "JAEGER_NAME" in your local .env file to "http://YOUR-LOCAL-IP:4317/"
start the container.  enter it and run `pytest`.
then go to http://localhost:16686/  .  you should see traces from the app in the dashboard.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? n
- integration tests? n

# Interested parties
Tag (@ mention) interested parties: @awoods 
