### PR TITLE
ETD-161: fix records updated counter & duplication checking

### DIFF
--- a/etd/worker.py
+++ b/etd/worker.py
@@ -215,6 +215,7 @@ class Worker():
                 if marcXmlRecord:
                     xmlCollectionOut.write(marcXmlRecord)
                     wroteXmlRecords = True
+                    numRecordsUpdated = numRecordsUpdated + 1                  
 
         # If marcxml file was written successfully, finish xml records 
 	    # collection file and then send it to dropbox for Alma to load
@@ -244,7 +245,6 @@ class Worker():
                     current_span.add_event(f'{xmlCollectionFile} was sent to {dropboxUser}@{dropboxServer}:{targetFile}')
                     self.logger.debug("uploaded proquest id: " + str(marcXmlValues['proquestId']))
                     self.logger.debug("uploaded file: " + str(targetFile))
-                    numRecordsUpdated += 1
 
             xfer.close()
 

--- a/etd/worker.py
+++ b/etd/worker.py
@@ -170,9 +170,9 @@ class Worker():
                 with open(alreadyRunRef, 'r') as alreadyRunTable:
                     for line in alreadyRunTable:
                         if f'Alma {batch} {school}' == line.rstrip():
-                            notifyJM.log('fail', 'Batch has already been run. Use --force to re-run.', True)
+                            notifyJM.log('fail', f'Batch {batch} has already been run. Use force flag to re-run.', True)
                             current_span.set_status(Status(StatusCode.ERROR))
-                            current_span.add_event('Batch has already been run. Use force flag to re-run.')
+                            current_span.add_event(f'Batch {batch} has already been run. Use force flag to re-run.')
                             skipBatch = True
                             continue
             if skipBatch:
@@ -215,7 +215,10 @@ class Worker():
                 if marcXmlRecord:
                     xmlCollectionOut.write(marcXmlRecord)
                     wroteXmlRecords = True
-                    numRecordsUpdated = numRecordsUpdated + 1                  
+                    numRecordsUpdated = numRecordsUpdated + 1
+                    # Update processed reference file
+                    with open(alreadyRunRef, 'a+') as alreadyRunFile:
+                        alreadyRunFile.write(f'Alma {batch} {school}\n')                  
 
         # If marcxml file was written successfully, finish xml records 
 	    # collection file and then send it to dropbox for Alma to load
@@ -247,10 +250,6 @@ class Worker():
                     self.logger.debug("uploaded file: " + str(targetFile))
 
             xfer.close()
-
-            # Update processed reference file
-            with open(alreadyRunRef, 'a+') as alreadyRunFile:
-                alreadyRunFile.write(f'Alma {batch} {school}\n')
 
             # Store our marc xml variables
             with open(variableOutFile, 'w') as variablesOut:


### PR DESCRIPTION
**ETD-161: fix records updated counter & duplication checking**
* * *

**JIRA Ticket**: https://at-harvard.atlassian.net/browse/ETD-161


# What does this Pull Request do?
-fixes records updated counter in job monitor
-prevents batches from being re-processed

# How should this be tested?

1) download branch
2) copy.env.example to .env and set dev settings. 
3) get `alma_dropbox_id_rsa` from the vault and put in ._/ssh/alma_dropbox_id_rsa_ then get `known_hosts `from vault and put into `.ssh/known_hosts`
4) download the test dir and files here
[testdirs.zip](https://github.com/harvard-lts/etd_alma_service/files/13210739/testdirs.zip)
and unzip it at the repo directory root.
5) start up container `docker-compose -f docker-compose-local.yml up -d --build --force-recreate`
6) enter container `docker exec -it etd-alma-service bash`
7) at the shell, type `python3 scripts/invoke-task.py`
8) go to job monitor https://jobmon-dev.lib.harvard.edu/job_status/job_id/76  and look at the most recent job. it should show the correct number of records.
9) repeat steps 7 & 8, and then check the job monitor. the most recent job should have failed with the message "Batch _BATCHNAME_ has already been run. Use the force flag to re-run."

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? y
- integration tests? y

# Interested parties
Tag (@ mention) interested parties: @awoods 
