### PR TITLE
Etd 161: itest

### DIFF
--- a/etd/worker.py
+++ b/etd/worker.py
@@ -173,15 +173,16 @@ class Worker():
             skipBatch = False
 
             # Do not re-run a processed batch unless forced #- test
-            if ((not force) and (os.path.exists(alreadyRunRef))):
-                with open(alreadyRunRef, 'r') as alreadyRunTable:
-                    for line in alreadyRunTable:
-                        if f'Alma {batch} {school}' == line.rstrip():
-                            notifyJM.log('fail', f'Batch {batch} has already been run. Use force flag to re-run.', True)
-                            current_span.set_status(Status(StatusCode.ERROR))
-                            current_span.add_event(f'Batch {batch} has already been run. Use force flag to re-run.')
-                            skipBatch = True
-                            continue
+            if (not integration_test):
+                if ((not force) and (os.path.exists(alreadyRunRef))):
+                    with open(alreadyRunRef, 'r') as alreadyRunTable:
+                        for line in alreadyRunTable:
+                            if f'Alma {batch} {school}' == line.rstrip():
+                                notifyJM.log('fail', f'Batch {batch} has already been run. Use force flag to re-run.', True)
+                                current_span.set_status(Status(StatusCode.ERROR))
+                                current_span.add_event(f'Batch {batch} has already been run. Use force flag to re-run.')
+                                skipBatch = True
+                                continue
             if skipBatch:
                 continue
             # Let the Job Monitor know that the job has started
@@ -224,7 +225,7 @@ class Worker():
                     wroteXmlRecords = True
                     numRecordsUpdated = numRecordsUpdated + 1
                     # Update processed reference file
-                    if not integration_test:
+                    if (not integration_test):
                         with open(alreadyRunRef, 'a+') as alreadyRunFile:					
                             alreadyRunFile.write(f'Alma {batch} {school}\n')                  
 

--- a/etd/worker.py
+++ b/etd/worker.py
@@ -62,7 +62,7 @@ metsDimNamespace    = '{http://www.dspace.org/xmlns/dspace/dim}'
 
 yyyymmdd          = get_date_time_stamp('day')
 yymmdd            = yyyymmdd[2:]
-xmlCollectionFile = f'AlmaDelivery_{yyyymmdd}.xml'
+xmlCollectionFileName = f'AlmaDelivery_{yyyymmdd}.xml'
 
 reTheTitle = re.compile('"?(the) .*', re.IGNORECASE)
 reAnTitle  = re.compile('"?(an) .*', re.IGNORECASE)
@@ -115,6 +115,7 @@ class Worker():
         force = False
         verbose = False
         integration_test = False
+        current_span = trace.get_current_span()
         if FEATURE_FLAGS in message:
             feature_flags = message[FEATURE_FLAGS]
             if (ALMA_FEATURE_FORCE_UPDATE_FLAG in feature_flags and
@@ -123,10 +124,11 @@ class Worker():
             if (ALMA_FEATURE_VERBOSE_FLAG in feature_flags and
                 feature_flags[ALMA_FEATURE_VERBOSE_FLAG] == "on"):
                 verbose = True
-        if (INTEGRATION_TEST in feature_flags and
-            feature_flags[INTEGRATION_TEST] == True):
+        if (INTEGRATION_TEST in message and
+            message[INTEGRATION_TEST] == True):
             integration_test = True
-        current_span = trace.get_current_span()
+            self.logger.info('running integration test for alma service')	
+            current_span.add_event("running integration test for alma service")
         current_span.add_event("sending to alma worker main")
         self.logger.info('sending to alma worker main')
         self.send_to_alma_worker(force, verbose, integration_test)
@@ -158,6 +160,7 @@ class Worker():
               batchesIn.append([school, batch])
 
         # Start xml record collection output file
+        xmlCollectionFile = xmlCollectionFileName
         if integration_test:
             xmlCollectionFile = f'AlmaDeliveryTest_{yyyymmdd}.xml'
         xmlCollectionOut = open(xmlCollectionFile, 'w')

--- a/etd/worker.py
+++ b/etd/worker.py
@@ -159,7 +159,7 @@ class Worker():
 
         # Start xml record collection output file
         if integration_test:
-            xmlCollectionFile = f'{dataDir}/out/AlmaDeliveryTest_{yyyymmdd}.xml'
+            xmlCollectionFile = f'AlmaDeliveryTest_{yyyymmdd}.xml'
         xmlCollectionOut = open(xmlCollectionFile, 'w')
         xmlCollectionOut.write('<?xml version="1.0" encoding="UTF-8"?>\n')
         xmlCollectionOut.write(f'{xmlStartCollection}\n')


### PR DESCRIPTION
**integration test for etd-161**
* * *

**JIRA Ticket**: https://at-harvard.atlassian.net/browse/ETD-161


# What does this Pull Request do?
integration test for etd-161
this makes it aware for etd-integration-tests

# How should this be tested?
1) download branch
2) get `alma_proquest_id_rsa` &` known_hosts` from vault, put in `.ssh/`
3) copy env-example to .env and set to dev settings
4) modify scripts/invoke-task.py to send this json message:
```
{
    "job_ticket_id": "integration_testing", "integration_test": true,
    "feature_flags": 
    {
        "dash_feature_flag": "on",
        "alma_feature_flag": "on",
        "send_to_drs_feature_flag": "off",
        "drs_holding_record_feature_flag": "off"
    }
}
```
5) start container `docker-compose -f docker-compose-local.yml up -d --build --force-recreate`
6) `python3 scripts/invoke-task.py`
7) `sftp -i .ssh/alma_dropbox_id_rsa huletd@hegel` and then do `ls -l incoming`. 
you should see a file like this
`-rw-r--r--    1 huletd   4000        13789 Nov  2 22:01 AlmaDeliveryTest_20231102.xml`
if the alma test xml file is there then the test worked.
8) shutdown container `docker-compose -f docker-compose-local.yml down `

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? y
- integration tests? y

# Interested parties
Tag (@ mention) interested parties: @awoods 
