### PR TITLE
ETD-161: variables.py creation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,7 @@ ALMA_HEALTHCHECK_URL=
 jobMonitor=
 adminMailTo=
 adminMailFrom=
+
+MONGO_DB_NAME=
+MONGO_DB_COLLECTION=
+MONGO_URL=

--- a/etd/worker.py
+++ b/etd/worker.py
@@ -198,14 +198,20 @@ class Worker():
             metsFile = f'{dataDir}/in/{batch}/mets.xml'
             if not os.path.exists(metsFile):
                 notifyJM.log('fail', f"{metsFile} not found", True)
-                notifyJM.report('stopped')
-                return False
+                notifyJM.log('fail', f'skippping batch {batch} for school {school}', True)
+                current_span.set_status(Status(StatusCode.ERROR))
+                current_span.add_event(f'skippping batch {batch} for school {school}')
+                self.logger.error(f'skippping batch {batch} for school {school}')
+                continue
 
             mapFile = f'{batchOutDir}/mapfile'
             if not os.path.exists(mapFile):
                 notifyJM.log('fail', f"{mapFile} not found", True)
-                notifyJM.report('stopped')
-                return False
+                notifyJM.log('fail', f'skippping batch {batch} for school {school}', True)
+                current_span.set_status(Status(StatusCode.ERROR))
+                current_span.add_event(f'skippping batch {batch} for school {school}')
+                self.logger.error(f'skippping batch {batch} for school {school}')
+                continue
 
             # Get needed data from mets file
             marcXmlValues = getFromMets(metsFile, verbose)

--- a/etd/worker.py
+++ b/etd/worker.py
@@ -230,7 +230,10 @@ class Worker():
                     # Update processed reference file
                     if (not integration_test):
                         with open(alreadyRunRef, 'a+') as alreadyRunFile:					
-                            alreadyRunFile.write(f'Alma {batch} {school}\n')                  
+                            alreadyRunFile.write(f'Alma {batch} {school}\n')
+                    # Store our marc xml variables
+                    with open(variableOutFile, 'w') as variablesOut:
+                        variablesOut.write(f'marcXmlValues = {marcXmlValues}\n')
 
         # If marcxml file was written successfully, finish xml records 
 	    # collection file and then send it to dropbox for Alma to load
@@ -262,10 +265,6 @@ class Worker():
                     self.logger.debug("uploaded file: " + str(targetFile))
 
             xfer.close()
-
-            # Store our marc xml variables
-            with open(variableOutFile, 'w') as variablesOut:
-                variablesOut.write(f'marcXmlValues = {marcXmlValues}\n')
 
             recordsWereUpdated = True
             # Otherwise, remove file

--- a/etd/worker.py
+++ b/etd/worker.py
@@ -55,9 +55,9 @@ alreadyRunRef       = f'{filesDir}/already_processed.ref'
 dashLink            = 'https://nrs.harvard.edu/urn-3:HUL.InstRepos:'
 notifyJM            = False
 jobCode             = 'etds2alma'
-mongoUrl			= os.getenv('MONGO_URL')
-mongoDbName			= os.getenv('MONGO_DB_NAME')
-mongoDbCollection	= os.getenv('MONGO_DB_COLLECTION')
+mongoUrl            = os.getenv('MONGO_URL')
+mongoDbName         = os.getenv('MONGO_DB_NAME')
+mongoDbCollection   = os.getenv('MONGO_DB_COLLECTION')
 
 metsDmdSecNamespace = '{http://www.loc.gov/METS/}'
 metsDimNamespace    = '{http://www.dspace.org/xmlns/dspace/dim}'
@@ -175,7 +175,6 @@ class Worker():
         numRecordsUpdated = 0
         for (school, batch) in batchesIn:
             batchOutDir      = f'{dataDir}/out/{batch}'
-            variableOutFile  = f'{batchOutDir}/variables.py'
             skipBatch = False
 
             # Do not re-run a processed batch unless forced #- test
@@ -240,9 +239,6 @@ class Worker():
                     if (not integration_test):
                         with open(alreadyRunRef, 'a+') as alreadyRunFile:					
                             alreadyRunFile.write(f'Alma {batch} {school}\n')
-                    # Store our marc xml variables
-                    with open(variableOutFile, 'w') as variablesOut:
-                        variablesOut.write(f'marcXmlValues = {marcXmlValues}\n')
 
         # If marcxml file was written successfully, finish xml records 
 	    # collection file and then send it to dropbox for Alma to load

--- a/etd/worker.py
+++ b/etd/worker.py
@@ -55,6 +55,9 @@ alreadyRunRef       = f'{filesDir}/already_processed.ref'
 dashLink            = 'https://nrs.harvard.edu/urn-3:HUL.InstRepos:'
 notifyJM            = False
 jobCode             = 'etds2alma'
+mongoUrl			= os.getenv('MONGO_URL')
+mongoDbName			= os.getenv('MONGO_DB_NAME')
+mongoDbCollection	= os.getenv('MONGO_DB_COLLECTION')
 
 metsDmdSecNamespace = '{http://www.loc.gov/METS/}'
 metsDimNamespace    = '{http://www.dspace.org/xmlns/dspace/dim}'

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ opentelemetry-semantic-conventions==0.40b0
 packaging==23.1
 pluggy==1.0.0
 project-paths==1.1.1
+pymongo==3.12.1
 pysftp==0.2.9
 pytest==7.3.1
 pytest-mock==3.10.0


### PR DESCRIPTION
**Create variables.py in same place where dupe check is done.**
* * *

**JIRA Ticket**: https://at-harvard.atlassian.net/browse/ETD-161
https://at-harvard.atlassian.net/browse/ETD-300


# What does this Pull Request do?
Moved variables.py creation code block to same place where dupe check is to fix a potential bug.
Skips batches with missing maps or mets files instead of exiting completely.
Also includes updated example .env file for mongo db calls (ETD-300).

# How should this be tested?
1) download branch
2) get `alma_proquest_id_rsa` &` known_hosts` from vault, put in `.ssh/`
3) copy env-example to .env and set to dev settings
4) modify scripts/invoke-task.py to send this json message:
```
{
    "job_ticket_id": "integration_testing", "integration_test": true,
    "feature_flags": 
    {
        "dash_feature_flag": "on",
        "alma_feature_flag": "on",
        "send_to_drs_feature_flag": "off",
        "drs_holding_record_feature_flag": "off"
    }
}
```
5) start container `docker-compose -f docker-compose-local.yml up -d --build --force-recreate`
6) `python3 scripts/invoke-task.py`
7)` ls -l data/out/proquest2022060801-907348-gsd/variables.py`
you should see something like this:
-rw-r--r-- 1 etdadm etdadm 2433 Nov  3 22:11 data/out/proquest2022060801-907348-gsd/variables.py
8) `sftp -i .ssh/alma_dropbox_id_rsa huletd@hegel` and then do `ls -l incoming`. 
you should see a file like this
`-rw-r--r--    1 huletd   4000        13789 Nov  2 22:01 AlmaDeliveryTest_20231102.xml`
9) if the alma test xml file and the variables.py file exist then the script worked.
10) shutdown container `docker-compose -f docker-compose-local.yml down `

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? n
- integration tests? y

# Interested parties
Tag (@ mention) interested parties: @awoods 