### PR TITLE
fixed wrong var assignment in escapeStr

### DIFF
--- a/etd/worker.py
+++ b/etd/worker.py
@@ -638,7 +638,7 @@ def writeMarcXml(batch, batchOutDir, marcXmlValues, verbose):  # pragma: no cove
 							if len(marcXmlValues['subjects']) > 0:
 								marcXmlValues['subjects'].reverse()
 								for subject in marcXmlValues['subjects']:
-									subject = escapeStr(pqSubject)
+									subject = escapeStr(subject)
 									newDatafield653Str = datafield653Str.replace('SUBJECT_VALUE', subject)
 									parent.addnext(etree.fromstring(newDatafield653Str))
 									


### PR DESCRIPTION
**fixed wrong var assignment in escapeStr.**
* * *

**JIRA Ticket**: https://at-harvard.atlassian.net/browse/ETD-161


# How should this be tested?
**pytest only:**
1) to just run the integration test ONLY that is in pytest, run `pytest` at the shell prompt. all tests should pass 

**full testing (simulating an actual etd-alma-service run):**
1) download branch
2) get `alma_proquest_id_rsa` &` known_hosts` from vault, put in `.ssh/`
3) copy env-example to .env and set to dev settings, ensure mongo values are set
4) modify scripts/invoke-task.py to send this json message:
```
{
    "job_ticket_id": "integration_testing", "integration_test": true,
    "feature_flags": 
    {
        "dash_feature_flag": "on",
        "alma_feature_flag": "on",
        "send_to_drs_feature_flag": "off",
        "drs_holding_record_feature_flag": "off"
    }
}
```
5) start container `docker-compose -f docker-compose-local.yml up -d --build --force-recreate`
6) `python3 scripts/invoke-task.py`
7) Launch MongoDB or whatever client you use to view mongo, connect to the mongodb and view the "integration_test" collection. there should be a new record. if you see a new record then the test passed.
8) shutdown container `docker-compose -f docker-compose-local.yml down `


# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? y
- integration tests? y

# Interested parties
Tag (@ mention) interested parties: @awoods
