### PR TITLE
Added cleanMetsFile() method to strip FF character

### DIFF
--- a/etd/worker.py
+++ b/etd/worker.py
@@ -358,6 +358,7 @@ def getFromMets(metsFile, verbose):  # pragma: no cover
 	committeeMembers = []
 	
 	# Load mets file, get the root node and then parse
+	cleanMetsFile(metsFile)
 	metsTree   = etree.parse(metsFile)
 	rootMets   = metsTree.getroot()
 	rootDmdSec = rootMets.find(f'{metsDmdSecNamespace}dmdSec')
@@ -862,3 +863,11 @@ def escapeStr(s):
     # 4) escape xml characters
     s = escape(s)
     return s
+
+def cleanMetsFile(metsFile):
+    with open(metsFile, 'r') as metsFileIn:
+        metsFileContents = metsFileIn.readlines()
+
+    with open(metsFile, 'w') as metsFileOut:
+        for line in metsFileContents:
+            metsFileOut.write(line.replace(u'\u000c','').replace("&FF;",""))

--- a/tests/data/test.xml
+++ b/tests/data/test.xml
@@ -1,0 +1,1 @@
+<xml?><test>&FF;pass&FF;</test></xml>

--- a/tests/data/test.xml.orig
+++ b/tests/data/test.xml.orig
@@ -1,0 +1,1 @@
+<xml?><test>&FF;pass&FF;</test></xml>

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -2,9 +2,11 @@ from etd.worker import Worker
 from etd.worker import getFromMets
 from etd.worker import writeMarcXml
 from etd.worker import escapeStr
+from etd.worker import cleanMetsFile
 import requests
 import lxml.etree as ET
 import os
+import shutil
 
 generatedMarcXmlValues = None
 abstractText = 'The "Naming Expeditor" project aims to demystify the ' \
@@ -154,3 +156,15 @@ class TestWorkerClass():
         line = "     “<This & That  Tests>”   \u0000\u0009\u000a\u000c\u000d"
         newLine = escapeStr(line)
         assert newLine == ' "&lt;This &amp; That Tests&gt;" '
+
+    def test_cleanMetsFile(self):
+        testFile = "./tests/data/test.xml"
+        resetFile = "./tests/data/test.xml.orig"
+        cleanMetsFile(testFile)
+        assert os.path.exists(testFile)
+        f = open(testFile)
+        contents = f.read()
+        f.close()
+        # reset file
+        shutil.copy2(resetFile, testFile)
+        assert contents == "<xml?><test>pass</test></xml>"


### PR DESCRIPTION
**Added cleanMetsFile() method to strip FF character**
* * *

**JIRA Ticket**: https://at-harvard.atlassian.net/browse/ETD-317


# What does this Pull Request do?
Strips out the form feed character prior to xml parsing to prevent etd-alma-service from crashing.

# How should this be tested?

1) download branch
2) get `alma_proquest_id_rsa` &` known_hosts` from vault and put in `.ssh/`
3) copy env-example to .env and set to dev settings, ensure mongo values are set
4) start container `docker-compose -f docker-compose-local.yml up -d --build --force-recreate`
5) `pytest tests/unit`. All tests should pass
6) shutdown container `docker-compose -f docker-compose-local.yml down `


# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? y
- integration tests? n

# Interested parties
Tag (@ mention) interested parties: @awoods 
