### PR TITLE
ETD-317-4: Add keys to degreeLevelTracing lookup table

### DIFF
--- a/etd/etds2alma_tables.py
+++ b/etd/etds2alma_tables.py
@@ -47,7 +47,6 @@ degreeLevelTracing = {
 	"Masters": "Theses",
 	"Master's": "Theses",
 	"Doctoral": "Dissertations",
-	"Doctoral Dissertation": "Dissertations"
 }
 
 # A Python dictionary (or associtive array or hash) of dictionaries

--- a/etd/etds2alma_tables.py
+++ b/etd/etds2alma_tables.py
@@ -42,9 +42,12 @@ degreeCodeName = {
 # to map degree level to degree level tracing used in datafield 830 subfield p
 degreeLevelTracing = {
 	"Bachelor's": "Theses",
+	"Bachelors": "Theses",
 	"Undergraduate": "Theses",
 	"Masters": "Theses",
-	"Doctoral": "Dissertations"
+    "Master's": "Theses",
+	"Doctoral": "Dissertations",
+    "Doctoral Dissertation": "Dissertations"
 }
 
 # A Python dictionary (or associtive array or hash) of dictionaries

--- a/etd/etds2alma_tables.py
+++ b/etd/etds2alma_tables.py
@@ -45,9 +45,9 @@ degreeLevelTracing = {
 	"Bachelors": "Theses",
 	"Undergraduate": "Theses",
 	"Masters": "Theses",
-    "Master's": "Theses",
+	"Master's": "Theses",
 	"Doctoral": "Dissertations",
-    "Doctoral Dissertation": "Dissertations"
+	"Doctoral Dissertation": "Dissertations"
 }
 
 # A Python dictionary (or associtive array or hash) of dictionaries

--- a/etd/worker.py
+++ b/etd/worker.py
@@ -731,7 +731,7 @@ def writeMarcXml(batch, batchOutDir, marcXmlValues, verbose):  # pragma: no cove
 					if child.attrib['code'] == 'p':
 						if schools[marcXmlValues['school']]['degree_level_tracing']:
 							if 'degreeLevel' in marcXmlValues:
-								childText  = child.text.replace('DEGREE_LEVEL_TRACING_VALUE', degreeLevelTracing[marcXmlValues['degreeLevel']])
+								childText  = child.text.replace('DEGREE_LEVEL_TRACING_VALUE', degreeLevelTracing[normalizeLookupKey(marcXmlValues['degreeLevel'])])
 								child.text = childText
 							else:
 								notifyJM.log('fail', f"Degree level was not found in mets.xml. Cannot continue writing {xmlRecordFile}.", True)
@@ -874,3 +874,7 @@ def cleanMetsFile(metsFile):
         for line in metsFileContents:
             line = r.sub('', line)			
             metsFileOut.write(line)
+
+def normalizeLookupKey(k):
+	# return first word of key
+	return k.split()[0]

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -3,6 +3,7 @@ from etd.worker import getFromMets
 from etd.worker import writeMarcXml
 from etd.worker import escapeStr
 from etd.worker import cleanMetsFile
+from etd.worker import normalizeLookupKey
 import requests
 import lxml.etree as ET
 import os
@@ -185,6 +186,7 @@ class TestWorkerClass():
         assert generatedMarcXmlValues['degreeLevel'] == "Master's"
         assert degreeLevelTracing[generatedMarcXmlValues['degreeLevel']] == \
             "Theses"
-        assert degreeLevelTracing["Doctoral Dissertation"] == "Dissertations"
+        assert degreeLevelTracing[normalizeLookupKey("Doctoral Dissertation")]\
+            == "Dissertations"
         assert degreeLevelTracing["Master's"] == "Theses"
         assert degreeLevelTracing["Bachelors"] == "Theses"

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -7,6 +7,7 @@ import requests
 import lxml.etree as ET
 import os
 import shutil
+from etd.etds2alma_tables import degreeLevelTracing
 
 generatedMarcXmlValues = None
 abstractText = 'The "Naming Expeditor" project aims to demystify the ' \
@@ -179,3 +180,11 @@ class TestWorkerClass():
         assert marcXmlValues['author'] == 'Zinn, Eric Michael'
         assert marcXmlValues['title'] == 'Combinatorial Ancestral AAV ' \
             'Capsid Libraries Enable Multidimensional Study of Vector Biology'
+
+    def test_degreeLevelLookup(self):
+        assert generatedMarcXmlValues['degreeLevel'] == "Master's"
+        assert degreeLevelTracing[generatedMarcXmlValues['degreeLevel']] == \
+            "Theses"
+        assert degreeLevelTracing["Doctoral Dissertation"] == "Dissertations"
+        assert degreeLevelTracing["Master's"] == "Theses"
+        assert degreeLevelTracing["Bachelors"] == "Theses"


### PR DESCRIPTION
**Add keys to degreeLevelTracing lookup table**
* * *

**JIRA Ticket**: https://at-harvard.atlassian.net/browse/ETD-317


# What does this Pull Request do?
Add keys to degreeLevelTracing lookup table to prevent parser from crashing.

# How should this be tested?

1) download branch
2) get `alma_proquest_id_rsa` &` known_hosts` from vault and put in `.ssh/`
3) copy env-example to .env and set to dev settings, ensure mongo values are set
4) start container `docker-compose -f docker-compose-local.yml up -d --build --force-recreate`
5) `pytest tests/unit`. All tests should pass
6) shutdown container `docker-compose -f docker-compose-local.yml down `


# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? y
- integration tests? n

# Interested parties
Tag (@ mention) interested parties: @awoods 

