### PR TITLE
ETD-330: debugging statements & explicitly close mongo client 

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -47,6 +47,8 @@ class TestWorkerIntegrationClass():
                               last_modified_date, alma_dropbox_submission_date,
                               directory_id,
                               "integration_test", mongo_db)
+        if (mongo_client is not None):
+            mongo_client.close()
         # Assert that the function returns True
         assert result
 


### PR DESCRIPTION
**Added debug statements & explicitly close mongo client in send_to_alma_main()  &  int test**
* * *

**JIRA Ticket**: https://at-harvard.atlassian.net/browse/ETD-330

# What does this Pull Request do?
Added debugging statements & explicitly close mongo client when send_to_alma_main() finishes and in the integration test.

# How should this be tested?

1. download branch
2. get alma_proquest_id_rsa & known_hosts from vault and put in .ssh/
3. copy env-example to .env and set to dev settings, ensure mongo values are set
4. start container docker-compose -f docker-compose-local.yml up -d --build --force-recreate
5. pytest tests/integration. All tests should pass
6. shutdown container docker-compose -f docker-compose-local.yml down 


# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? n
- integration tests? y

# Interested parties
Tag (@ mention) interested parties: @awoods 
