### PR TITLE
ETD-281: Prepare logging for production

### DIFF
--- a/etd/__init__.py
+++ b/etd/__init__.py
@@ -16,7 +16,8 @@ def configure_logger():  # pragma: no cover
     log_file_path = os.getenv("LOGFILE_PATH",
                               "/home/etdadm/logs/etd_alma")
     formatter = logging.Formatter(
-                '%(asctime)s - %(name)s - %(levelname)s - [%(filename)s:%(funcName)s:%(lineno)d] - %(message)s')
+                '%(asctime)s - %(name)s - %(levelname)s - ' +
+                '[%(filename)s:%(funcName)s:%(lineno)d] - %(message)s')
 
     console_handler = logging.StreamHandler()
     console_handler.setFormatter(formatter)

--- a/etd/__init__.py
+++ b/etd/__init__.py
@@ -16,7 +16,7 @@ def configure_logger():  # pragma: no cover
     log_file_path = os.getenv("LOGFILE_PATH",
                               "/home/etdadm/logs/etd_alma")
     formatter = logging.Formatter(
-                '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+                '%(asctime)s - %(name)s - %(levelname)s - [%(filename)s:%(funcName)s:%(lineno)d] - %(message)s')
 
     console_handler = logging.StreamHandler()
     console_handler.setFormatter(formatter)

--- a/etd/worker.py
+++ b/etd/worker.py
@@ -141,7 +141,7 @@ class Worker():
         current_span.add_event("sending to alma worker main")
         self.logger.info('sending to alma worker main')
         self.send_to_alma_worker(force, verbose, integration_test)
-        self.logger.info('complete')
+        self.logger.info('export completed')
         return True
 		
     @tracer.start_as_current_span("send_to_alma_worker_main")

--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -113,7 +113,7 @@ def send_to_alma(json_message):
                         CREATE ALMA RECORD")
                     worker = Worker()
                     msg = worker.send_to_alma(json_message)
-                    logger.debug(msg)
+                    logger.debug("task succeeded: " + str(msg))
                 else:
                     logger.debug("dash_feature_flag MUST BE ON FOR THE ALMA \
                         HOLDING TO BE CREATED. dash_feature_flag \


### PR DESCRIPTION
**Prepare logging for production.**
* * *

**JIRA Ticket**: https://at-harvard.atlassian.net/browse/ETD-281


# What does this Pull Request do?
adds filename and line number info to logs

# How should this be tested?
this has been moved to dev.
to test:
1) enter the container on cloud dev, `cd logs/etd_alma; ls -lat | head -5` to find the running log (it should be at the top), then tail -f <container_id_.log>
2) point your browser or curl at: https://ltsds-cloud-dev-1.lib.harvard.edu:10610/alma_service . You should get this json message `{"num_failed": 0, "tests_failed": [], "info": {}}` confirming no errors.
3) tail should show output similar to this:
`2023-12-14 20:08:39,918 - etd_alma - DEBUG - [tasks.py:send_to_alma:95] - message
2023-12-14 20:08:39,919 - etd_alma - DEBUG - [tasks.py:send_to_alma:96] - {'hello': 'world', 'identifier': '853755', 'integration_test': True, 'feature_flags': {'dash_feature_flag': 'on', 'alma_feature_flag': 'on', 'send_to_drs_feature_flag': 'off', 'drs_holding_record_feature_flag': 'off'}}
2023-12-14 20:08:39,920 - etd_alma - DEBUG - [tasks.py:send_to_alma:102] - processing id: 853755
2023-12-14 20:08:39,920 - etd_alma - DEBUG - [tasks.py:send_to_alma:111] - FEATURE IS ON>>>>>CREATE ALMA RECORD
2023-12-14 20:08:39,921 - etd_alma - INFO - [worker.py:send_to_alma:139] - running integration test for alma service
2023-12-14 20:08:39,921 - etd_alma - INFO - [worker.py:send_to_alma:142] - sending to alma worker main
2023-12-14 20:08:40,201 - etd_alma - DEBUG - [worker.py:send_to_alma_worker:266] - Wrote MARCXML record for proquest2023112701-853755-gsas for gsas
2023-12-14 20:08:40,202 - etd_alma - DEBUG - [worker.py:send_to_alma_worker:278] - MARCXML record for proquest2023112701-853755-gsas for gsas added to collection file
2023-12-14 20:08:40,203 - etd_alma - DEBUG - [worker.py:send_to_alma_worker:293] - Updating mongo...
2023-12-14 20:08:40,342 - etd_alma - INFO - [worker.py:write_record:866] - proquest id 28769235 written to mongo
2023-12-14 20:08:40,343 - etd_alma - DEBUG - [worker.py:send_to_alma_worker:309] - Proquest id 28769235 in proquest2023112701-853755-gsas for school gsas recorded in mongo
2023-12-14 20:08:41,077 - etd_alma - DEBUG - [worker.py:send_to_alma_worker:340] - uploaded proquest id: 28769235
2023-12-14 20:08:41,078 - etd_alma - DEBUG - [worker.py:send_to_alma_worker:341] - uploaded file: /incoming/AlmaDeliveryTestDev_202312142008.xml
2023-12-14 20:08:41,081 - etd_alma - DEBUG - [worker.py:send_to_alma_worker:356] - 1 records were updated
2023-12-14 20:08:41,297 - etd_alma - INFO - [worker.py:send_to_alma:144] - export completed
2023-12-14 20:08:41,298 - etd_alma - DEBUG - [tasks.py:send_to_alma:116] - task succeeded: True`

if you see something similar (but w/ different timestamps), then the test was successful.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? n
- integration tests? n

# Interested parties
Tag (@ mention) interested parties: @awoods
