### PR TITLE
Removal of 506 for inDASH and language change for 506 for nonDASH

### DIFF
--- a/etd/worker.py
+++ b/etd/worker.py
@@ -799,8 +799,6 @@ def writeMarcXml(batch, batchOutDir, marcXmlValues, verbose):  # pragma: no cove
 								child.text = childText
 							else:
 								removeNodes.add(parent)
-						elif child.attrib['code'] == 'a' and parent.attrib['ind1'] == '0':
-							pass
 						else:
 							removeNodes.add(parent)
 					elif child.attrib['code'] == 'a' and parent.attrib['ind1'] == '0':

--- a/templates/alma_marcxml_template.xml
+++ b/templates/alma_marcxml_template.xml
@@ -127,7 +127,7 @@
      </datafield>
 
      <datafield tag="506" ind1="0" ind2=" ">
-         <subfield code="a">Contact the Harvard University Archives about on-site viewing or obtaining a copy.</subfield>
+         <subfield code="a">Open for research. Contact the Harvard University Archives about on-site viewing or obtaining a copy.</subfield>
      </datafield>
 
      <datafield tag="583" ind1="1" ind2=" ">


### PR DESCRIPTION
**Removes the 506 from Alma if the record is in DASH (unless embargo exists)**
* * *

**JIRA Ticket**: https://at-harvard.atlassian.net/browse/ETD-376

# How should this be tested?

Already tested in dev and verified by Paul A.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? no
- integration tests? no

