### PR TITLE
Updated jobmon reporting level to warn for already processed

### DIFF
--- a/etd/worker.py
+++ b/etd/worker.py
@@ -208,7 +208,7 @@ class Worker():
                     with open(alreadyRunRef, 'r') as alreadyRunTable:
                         for line in alreadyRunTable:
                             if f'Alma {batch} {school}' == line.rstrip():
-                                notifyJM.log('fail', f'Batch {batch} has already been run. Use force flag to re-run.', True)
+                                notifyJM.log('warn', f'Batch {batch} has already been run. Use force flag to re-run.', True)
                                 current_span.set_status(Status(StatusCode.ERROR))
                                 current_span.add_event(f'Batch {batch} has already been run. Use force flag to re-run.')
                                 skipBatch = True


### PR DESCRIPTION
**Changed the JobMon reporting from 'fail' to 'warn' to avoid snow tickets in prod**
* * *

**JIRA Ticket**: https://at-harvard.atlassian.net/browse/ETD-410


# How should this be tested?

Already tested in dev and these are now warnings as expected: https://jobmon-dev.lib.harvard.edu/job_summary/job_id/76/run_id/1711044072

vs the old way where they were failures:
https://jobmon-dev.lib.harvard.edu/job_summary/job_id/76/run_id/1710820802

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? no 
- integration tests? no
